### PR TITLE
Fix building instructions and sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ hs_err_pid*
 /.idea/
 /.gradle/
 /buildSrc/.gradle/
+/buildSrc/build
+/plugin/pluginRepo

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ badge {
 You can specify manually which icons to process:
 ```
 badge {
-    iconNames = ["@mipmap/ic_launcher_cusom"]
+    iconNames = ["@mipmap/ic_launcher_custom"]
 }
 ```
 
@@ -99,6 +99,13 @@ badge {
     }
 }
 ```
+
+# Development
+- Make sure that the repository's directory is called 'app-badge', small letters,
+  as this name is using for the artifact's group name.
+- If you're building a new version, comment `classpath(BuildScriptPlugins.appBadge)` in the main
+  `build.gradle.kts`, then run `./gradlew :plugin:uploadArchives` to create a plugin in
+  `plugin/pluginRepo`.
 
 # Developed by 
 Sergey Chuprin - <gregamer@gmail.com>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
     const val kotlin = "1.3.11"
     const val androidX = "1.0.0"
     const val gradlePlugin = "3.3.0"
-    const val projectVersion = "1.0.2"
+    const val projectVersion = "1.0.3"
 }
 
 object BuildScriptPlugins {

--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Jan 14 23:27:45 MSK 2019
-ndk.dir=C\:\\Users\\Sergey\\AppData\\Local\\Android\\Sdk\\ndk-bundle
-sdk.dir=C\:\\Users\\Sergey\\AppData\\Local\\Android\\Sdk

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -19,9 +19,11 @@ dependencies {
 
 // Upload archive to rootProject/plugin/badgeRepo folder to test plugin locale.
 tasks.named<Upload>("uploadArchives") {
+    val pluginRepoUrl = file("pluginRepo").toURI()
+    print(pluginRepoUrl)
     repositories.withGroovyBuilder {
         "mavenDeployer" {
-            "repository"("url" to "file://pluginRepo")
+            "repository"("url" to pluginRepoUrl)
         }
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,8 +12,7 @@ android {
 
 badge {
     iconNames = listOf(
-        "@mipmap/ic_launcher_custom",
-        "@mipmap/ic_launcher_foreground"
+        "@mipmap/ic_launcher_custom"
     )
     buildTypes {
         create("debug") {


### PR DESCRIPTION
A few fixes:

- In the sample app, since #2  we no longer need to pass the foreground image explicitly, the plugin will detect it automatically
- Various instructions on building
- Make `pluginRepo` path handling work from any directory, ie. `./gradlew :plugin:uploadArchives` now works
- Remove `local.properties` which should not be here